### PR TITLE
add rdiff-backup

### DIFF
--- a/package/libs/librsync/Makefile
+++ b/package/libs/librsync/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2006-2010 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=librsync
+PKG_VERSION:=0.9.7
+PKG_RELEASE:=4
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/librsync
+PKG_MD5SUM:=24cdb6b78f45e0e83766903fd4f6bc84
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+TARGET_CFLAGS += $(FPIC)
+
+define Package/librsync
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=implementation of the rolling-checksum algorithm
+  DEPENDS:=+libbz2 +libpopt +zlib
+  URL:=http://librsync.sourceforge.net/
+endef
+
+define Package/librsync/description
+	librsync implements the rolling-checksum algorithm of remote file
+	synchronization that was popularized by the rsync utility and is
+	used in rproxy. This algorithm transfers the differences between 2
+	files without needing both files on the same system.
+endef
+
+define Build/Configure
+	$(call Build/Configure/Default, \
+		--enable-shared \
+		--enable-static \
+	);
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/opt/include
+	$(CP) $(PKG_INSTALL_DIR)/opt/include/librsync{,-config}.h $(1)/opt/include/
+	$(INSTALL_DIR) $(1)/opt/lib
+	$(CP) $(PKG_INSTALL_DIR)/opt/lib/librsync.{a,so*} $(1)/opt/lib/
+endef
+
+define Package/librsync/install
+	$(INSTALL_DIR) $(1)/opt/lib
+	$(CP) $(PKG_INSTALL_DIR)/opt/lib/librsync.so.* $(1)/opt/lib/
+endef
+
+$(eval $(call BuildPackage,librsync))

--- a/package/libs/librsync/patches/001-4gb_files.patch
+++ b/package/libs/librsync/patches/001-4gb_files.patch
@@ -1,0 +1,31 @@
+diff -urN librsync-0.9.7/mdfour.h librsync-0.9.7.new/mdfour.h
+--- librsync-0.9.7/mdfour.h	2004-02-08 00:17:57.000000000 +0100
++++ librsync-0.9.7.new/mdfour.h	2009-08-08 16:08:57.000000000 +0200
+@@ -24,7 +24,7 @@
+ #include "types.h"
+ 
+ struct rs_mdfour {
+-    int                 A, B, C, D;
++    unsigned int                 A, B, C, D;
+ #if HAVE_UINT64
+     uint64_t            totalN;
+ #else
+diff -urN librsync-0.9.7/patch.c librsync-0.9.7.new/patch.c
+--- librsync-0.9.7/patch.c	2004-09-17 23:35:50.000000000 +0200
++++ librsync-0.9.7.new/patch.c	2009-08-08 16:10:40.000000000 +0200
+@@ -214,12 +214,12 @@
+     void            *buf, *ptr;
+     rs_buffers_t    *buffs = job->stream;
+ 
+-    len = job->basis_len;
+-    
+     /* copy only as much as will fit in the output buffer, so that we
+      * don't have to block or store the input. */
+-    if (len > buffs->avail_out)
++    if (job->basis_len > buffs->avail_out)
+         len = buffs->avail_out;
++    else
++	len = job->basis_len;
+ 
+     if (!len)
+         return RS_BLOCKED;

--- a/package/utils/rdiff-backup/Makefile
+++ b/package/utils/rdiff-backup/Makefile
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2006-2009 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+ 
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rdiff-backup
+PKG_VERSION:=1.2.8
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://savannah.nongnu.org/download/rdiff-backup/
+PKG_MD5SUM:=1a94dc537fcf74d6a3a80bd27808e77b
+
+PKG_BUILD_DEPENDS:=python
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/rdiff-backup
+  SUBMENU:=backup
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Incremental backup utility
+  URL:=http://www.nongnu.org/rdiff-backup
+  DEPENDS:=+python +librsync +libpopt +openssl-util
+endef
+
+define Package/rdiff-backup/description
+	rdiff-backup backs up one directory to another, possibly over a
+	network. The target directory ends up a copy of the source directory,
+	but extra reverse diffs are stored in a special subdirectory of that
+	target directory, so you can still recover files lost some time ago.
+	The idea is to combine the best features of a mirror and an incremental
+	backup.
+endef
+
+define PyPackage/rdiff-backup/filespec
++|/opt/bin/rdiff-backup
++|$(PYTHON_PKG_DIR)/rdiff_backup
+endef
+
+define Build/Compile
+	$(if $(Build/Compile/PyMod),,@echo Python packaging code not found.; false)
+	$(call Build/Compile/PyMod,., \
+		build --librsync-dir="$(STAGING_DIR)/opt" , \
+	)
+	$(call Build/Compile/PyMod,., \
+		install --prefix="$(PKG_INSTALL_DIR)/opt", \
+	)
+endef
+
+$(eval $(call PyPackage,rdiff-backup))
+$(eval $(call BuildPackage,rdiff-backup))

--- a/package/utils/rdiff-backup/patches/001-python_path.patch
+++ b/package/utils/rdiff-backup/patches/001-python_path.patch
@@ -1,0 +1,8 @@
+--- a/rdiff-backup
++++ b/rdiff-backup
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/opt/bin/python
+ # rdiff-backup -- Mirror files while keeping incremental changes
+ # Version 1.0.5 released November 11, 2006
+ # Copyright (C) 2001-2005  Ben Escoto <rdiff-backup@emerose.org>


### PR DESCRIPTION
Hi,

I've copied librsync and rdiff-backup from openwrt [packages](http://git.openwrt.org/?p=packages.git;a=tree;f=utils/rdiff-backup;h=be6330b4a1840ce71b2329c611871c9fe11aaaad;hb=f7bce3b11d4cb80d4a06ca0b013376b1d6db9cce). Tested on armv7, qnap ts-431.

That should fix issue #14.