### PR TITLE
Add mrouted 3.9.8 package

### DIFF
--- a/package/network/services/mrouted/Makefile
+++ b/package/network/services/mrouted/Makefile
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2006-2011 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mrouted
+PKG_VERSION:=3.9.8
+PKG_RELEASE:=$(PKG_SOURCE_VERSION)
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/troglobit/mrouted.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=3.9.8
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+
+include $(INCLUDE_DIR)/package.mk
+
+PKG_LICENSE:=3-clause BSD
+
+define Package/mrouted
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=
+  TITLE:=Multicast Routing Daemon (mrouted)
+  URL:=https://github.com/troglobit/mrouted
+endef
+
+define Package/mrouted/description
+  mrouted is a 3-clause BSD licensed implementation of the DVMRP multicast routing protocol. It can run on any UNIX based system, from embedded Linux systems to workstations, turning them into multicast routers with tunnel support, which can be used to cross non-multicast-aware routers.
+endef
+
+define Package/mrouted/conffiles
+/opt/etc/mrouted.conf
+endef
+
+TARGET_CFLAGS += -std=gnu99
+CONFIGURE_ARGS = --with-includes=$(LINUX_DIR)
+MAKE_FLAGS += prefix=/opt/ sysconfdif=/opt/etc/
+
+define Build/Compiled
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		CC="$(TARGET_CC)" \
+		USERCOMPILE="$(TARGET_CFLAGS)" \
+		prefix=/opt/ \
+		sysconfdir=/opt/etc/ \
+		 
+endef
+
+define Package/mrouted/install
+	$(INSTALL_DIR) $(1)/opt/etc/
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/mrouted.conf $(1)/opt/etc/
+	$(INSTALL_DIR) $(1)/opt/etc/init.d
+	$(INSTALL_BIN) ./files/S69mrouted $(1)/opt/etc/init.d/
+	$(INSTALL_DIR) $(1)/opt/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mrouted $(PKG_BUILD_DIR)/map-mbone $(PKG_BUILD_DIR)/mrinfo $(PKG_BUILD_DIR)/mtrace  $(1)/opt/sbin/
+endef
+
+$(eval $(call BuildPackage,mrouted))
+

--- a/package/network/services/mrouted/Makefile
+++ b/package/network/services/mrouted/Makefile
@@ -42,15 +42,6 @@ TARGET_CFLAGS += -std=gnu99
 CONFIGURE_ARGS = --with-includes=$(LINUX_DIR)
 MAKE_FLAGS += prefix=/opt/ sysconfdif=/opt/etc/
 
-define Build/Compiled
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		CC="$(TARGET_CC)" \
-		USERCOMPILE="$(TARGET_CFLAGS)" \
-		prefix=/opt/ \
-		sysconfdir=/opt/etc/ \
-		 
-endef
-
 define Package/mrouted/install
 	$(INSTALL_DIR) $(1)/opt/etc/
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/mrouted.conf $(1)/opt/etc/

--- a/package/network/services/mrouted/files/S69mrouted
+++ b/package/network/services/mrouted/files/S69mrouted
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-ENABLED=yes
+ENABLED=no
 PROCS=mrouted
-ARGS="-f /opt/etc/mrouted.conf"
+ARGS="-c /opt/etc/mrouted.conf"
 PREARGS=""
 DESC=$PROCS
 PATH=/opt/sbin:/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/package/network/services/mrouted/files/S69mrouted
+++ b/package/network/services/mrouted/files/S69mrouted
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+ENABLED=yes
+PROCS=mrouted
+ARGS="-f /opt/etc/mrouted.conf"
+PREARGS=""
+DESC=$PROCS
+PATH=/opt/sbin:/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+. /opt/etc/init.d/rc.func


### PR DESCRIPTION
Add a package for building mrouted multicast routing daemon. This will allow routing of multicast between vpn tunnels, interfaces and internet.

 * Note: for tunnel support kmod-ipip would be needed as a dependency.
 * Note: by default the service is disabled.