### PR TITLE
pimd: Add initial pimd package

### DIFF
--- a/configs/armv7.config
+++ b/configs/armv7.config
@@ -4101,6 +4101,7 @@ CONFIG_PACKAGE_ip-full=m
 # CONFIG_PACKAGE_net-tools-route is not set
 CONFIG_PACKAGE_nstat=m
 # CONFIG_PACKAGE_olsrd is not set
+CONFIG_PACKAGE_pimd=m
 CONFIG_PACKAGE_quagga=m
 CONFIG_PACKAGE_quagga-bgpd=m
 CONFIG_PACKAGE_quagga-isisd=m

--- a/configs/mipselsf.config
+++ b/configs/mipselsf.config
@@ -4078,6 +4078,7 @@ CONFIG_PACKAGE_ip-legacy=m
 # CONFIG_PACKAGE_mcproxy is not set
 # CONFIG_PACKAGE_net-tools-route is not set
 # CONFIG_PACKAGE_olsrd is not set
+CONFIG_PACKAGE_pimd=m
 CONFIG_PACKAGE_quagga=m
 CONFIG_PACKAGE_quagga-bgpd=m
 CONFIG_PACKAGE_quagga-isisd=m

--- a/package/network/services/pimd/Makefile
+++ b/package/network/services/pimd/Makefile
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2017 Joakim Plate <joakim.plate@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pimd
+PKG_VERSION:=2.4.0
+PKG_REV:=9f387158a346829973da2d47a05a56af0b0627fb
+PKG_RELEASE:=beta1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL=https://github.com/troglobit/pimd.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=$(PKG_REV)
+
+PKG_LICENSE_FILE:=LICENCE
+PKG_FIXUP:=autoreconf
+PKG_REMOVE_FILES:=autogen.sh aclocal.m4
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/pimd
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=
+  TITLE:=multicast routing daemon (PIM-SM/SSM)
+  URL:=https://github.com/troglobit/pimd
+endef
+
+define Package/pimd/description
+  pimd is a lightweight, stand-alone PIM-SM/SSM multicast routing
+  daemon available under the free 3-clause BSD license. This is the
+  restored original version from University of Southern California,
+  by Ahmed Helmy, Rusty Eddy and Pavlin Ivanov Radoslavov.
+endef
+
+define Package/pimd/conffiles
+  /opt/etc/pimd.conf
+endef
+
+define Package/pimd/install
+	$(INSTALL_DIR) $(1)/opt/etc/
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/opt/share/doc/pimd/pimd.conf $(1)/opt/etc/
+	$(INSTALL_DIR) $(1)/opt/etc/init.d
+	$(INSTALL_BIN) ./files/S69pimd $(1)/opt/etc/init.d/
+	$(INSTALL_DIR) $(1)/opt/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/opt/sbin/* $(1)/opt/sbin/
+endef
+
+$(eval $(call BuildPackage,pimd))
+

--- a/package/network/services/pimd/files/S69pimd
+++ b/package/network/services/pimd/files/S69pimd
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+ENABLED=yes
+PROCS=pimd
+ARGS="-N -c /opt/etc/pimd.conf"
+PREARGS=""
+DESC=$PROCS
+PATH=/opt/sbin:/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+. /opt/etc/init.d/rc.func


### PR DESCRIPTION
The default configuration will not add any interfaces for routing since
there could be a security implications of allowing routing on internet
facing interfaces.