### PR TITLE
Create 942-ubsan-fix-check-empty-string.patch

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -233,6 +233,7 @@ foreach my $mirror (@ARGV) {
 			push @extra, "$extra[0]/longterm/v$1";
 		}		
 		foreach my $dir (@extra) {
+			push @mirrors, "https://cdn.kernel.org/pub/linux/kernel/v2.6";
 			push @mirrors, "https://cdn.kernel.org/pub/$dir";
 			push @mirrors, "https://mirror.rackspace.com/kernel.org/$dir";
 			push @mirrors, "http://download.xs4all.nl/ftp.kernel.org/pub/$dir";

--- a/toolchain/gcc/patches/6.3.0/942-ubsan-fix-check-empty-string.patch
+++ b/toolchain/gcc/patches/6.3.0/942-ubsan-fix-check-empty-string.patch
@@ -1,0 +1,11 @@
+--- a/gcc/ubsan.c
++++ b/gcc/ubsan.c
+@@ -1471,7 +1471,7 @@
+ 
+   expanded_location xloc = expand_location (loc);
+   if (xloc.file == NULL || strncmp (xloc.file, "\1", 2) == 0
+-      || xloc.file == '\0' || xloc.file[0] == '\xff'
++      || xloc.file[0] == '\0' || xloc.file[0] == '\xff'
+       || xloc.file[1] == '\xff')
+     return false;
+ 


### PR DESCRIPTION
### Fixes gcc compile complaning

```
/root/Entware-ng/build_dir/toolchain-arm_cortex-a9_gcc-6.3.0_glibc-2.23_eabi/gcc-6.3.0/gcc/ubsan.c:1474:23: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
       || xloc.file == '\0' || xloc.file[0] == '\xff'
                       ^~~~
Makefile:1085: recipe for target 'ubsan.o' failed
make[4]: *** [ubsan.o] Error 1
make[4]: Leaving directory '/root/Entware-ng/build_dir/toolchain-arm_cortex-a9_gcc-6.3.0_glibc-2.23_eabi/gcc-6.3.0-minimal/gcc'
Makefile:4114: recipe for target 'all-gcc' failed
make[3]: *** [all-gcc] Error 2
```


### kernel headers links all fail

```
ake[3]: Leaving directory '/root/Entware-ng/build_dir/toolchain-arm_cortex-a9_gcc-6.3.0_glibc-2.23_eabi/gcc-6.3.0-minimal'
mkdir -p /root/Entware-ng/staging_dir/host/stamp
touch /root/Entware-ng/build_dir/toolchain-arm_cortex-a9_gcc-6.3.0_glibc-2.23_eabi/gcc-6.3.0-minimal/.built
touch /root/Entware-ng/staging_dir/host/stamp/.gcc_minimal_installed
make[2]: Leaving directory '/root/Entware-ng/toolchain/gcc/minimal'
make[1]: Circular toolchain/kernel-headers/compile <- toolchain/kernel-headers/compile dependency dropped.
make[2]: Entering directory '/root/Entware-ng/toolchain/kernel-headers'
mkdir -p /root/Entware-ng/dl
SHELL= flock /root/Entware-ng/tmp/.linux-2.6.36.4.tar.xz.flock -c '  	/root/Entware-ng/scripts/download.pl "/root/Entware-ng/dl" "linux-2.6.36.4.tar.xz" "x" "" "@KERNEL/linux/kernel/v2.x"    '
+ curl -f --connect-timeout 20 --retry 5 --location --insecure https://cdn.kernel.org/pub/linux/kernel/v2.x/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure https://mirror.rackspace.com/kernel.org/linux/kernel/v2.x/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://download.xs4all.nl/ftp.kernel.org/pub/linux/kernel/v2.x/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://mirrors.mit.edu/kernel/linux/kernel/v2.x/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://ftp.nara.wide.ad.jp/pub/kernel.org/linux/kernel/v2.x/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://www.ring.gr.jp/archives/linux/kernel.org/linux/kernel/v2.x/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure ftp://ftp.riken.jp/Linux/kernel.org/linux/kernel/v2.x/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
curl: (9) Server denied you to change to the given directory
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure ftp://www.mirrorservice.org/sites/ftp.kernel.org/pub/linux/kernel/v2.x/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
curl: (9) Server denied you to change to the given directory
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure https://cdn.kernel.org/pub/linux/kernel/v2.x/longterm/v2.6.36/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure https://mirror.rackspace.com/kernel.org/linux/kernel/v2.x/longterm/v2.6.36/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://download.xs4all.nl/ftp.kernel.org/pub/linux/kernel/v2.x/longterm/v2.6.36/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://mirrors.mit.edu/kernel/linux/kernel/v2.x/longterm/v2.6.36/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://ftp.nara.wide.ad.jp/pub/kernel.org/linux/kernel/v2.x/longterm/v2.6.36/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://www.ring.gr.jp/archives/linux/kernel.org/linux/kernel/v2.x/longterm/v2.6.36/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure ftp://ftp.riken.jp/Linux/kernel.org/linux/kernel/v2.x/longterm/v2.6.36/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (9) Server denied you to change to the given directory
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure ftp://www.mirrorservice.org/sites/ftp.kernel.org/pub/linux/kernel/v2.x/longterm/v2.6.36/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
curl: (9) Server denied you to change to the given directory
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://sources.lede-project.org/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://mirror2.openwrt.org/sources/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://downloads.openwrt.org/sources/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   184  100   184    0     0    184      0  0:00:01 --:--:--  0:00:01   469
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
+ curl -f --connect-timeout 20 --retry 5 --location --insecure http://pkg.entware.net/sources/linux-2.6.36.4.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed.
No more mirrors to try - giving up.
Makefile:100: recipe for target '/root/Entware-ng/dl/linux-2.6.36.4.tar.xz' failed
make[2]: *** [/root/Entware-ng/dl/linux-2.6.36.4.tar.xz] Error 2
make[2]: Leaving directory '/root/Entware-ng/toolchain/kernel-headers'
toolchain/Makefile:86: recipe for target 'toolchain/kernel-headers/compile' failed
make[1]: *** [toolchain/kernel-headers/compile] Error 2
make[1]: Leaving directory '/root/Entware-ng'
/root/Entware-ng/include/toplevel.mk:216: recipe for target 'toolchain/install' failed
```


-------------------------------

Compile tested: ubuntu17.04, 17.10
Run tested: armv7
